### PR TITLE
Local testing infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ Grammar-Convert-ABNF-Pegex-*
 .build*
 t/Test*
 t/*.bak
+
+.perl-version
+cpanfile.snapshot
+local/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,44 +1,48 @@
+Contributing to Grammar::Convert::ABNF::Pegex
+=============================================
 
-# Development
+## Getting Started
 
-The distribution is contained in a Git repository, so simply clone the
-repository
+If you have carton available you should just be able to
+clone this repo, change to the directory, and run `make test`.
 
-```
-$ git clone git://github.com/reneeb/Grammar-Convert-ABNF-Pegex.git
-```
+### Installing dependencies
 
-and change into the newly-created directory.
+The dependencies for this project are listed in its `cpanfile`,
+this file is usually handled by [Carton](https://metacpan.org/pod/Carton).
 
-```
-$ cd Grammar-Convert-ABNF-Pegex
-```
+Installing Carton can be done with any CPAN client into whichever version of perl you want to use.
 
-The project uses [`Dist::Zilla`](https://metacpan.org/pod/Dist::Zilla) to
-build the distribution, hence this will need to be installed before
-continuing:
+If you don't have permission, or just don't want to install things into your system perl, you can use [App::Plenv](https://github.com/tokuhirom/plenv) and the [perl-build](https://github.com/tokuhirom/perl-build) plugin, or [Perlbrew](https://perlbrew.pl/) to install different versions of perl.
 
-```
-$ cpanm Dist::Zilla
-```
+Once you have a version of perl to use for testing this, if you don't have a preference for a CPAN client, we recommend you use [cpanminus](https://metacpan.org/pod/App::cpanminus#Installing-to-system-perl).
 
-To install the required prequisite packages, run the following set of
-commands:
+With `plenv` you are able to get cpanminus with `plenv install-cpanm`.
 
-```
-$ dzil authordeps --missing | cpanm
-$ dzil listdeps --author --missing | cpanm
-```
+Otherwise, quoting the cpanminus quickstart instructions:
 
-The distribution can be tested like so:
+> Quickstart: Run the following command and it will install itself for you.
+> You might want to run it as a root with sudo if you want to
+> install to places like /usr/local/bin.
+>
+>   `% curl -L https://cpanmin.us | perl - App::cpanminus`
+>
+> If you don't have curl but wget, replace `curl -L` with `wget -O -`.
 
-```
-$ dzil test
-```
+Once you have cpanminus, you can install Carton with:
 
-To run the full set of tests (including author and release-process tests),
-add the `--author` and `--release` options:
+    cpanm Carton
 
-```
-$ dzil test --author --release
-```
+With `carton` available, you can run `make test` and make sure tests pass.  If they do, you're ready to start making changes and get ready to create a Pull Request.
+
+### Using Dist::Zilla
+
+The release of this distribution is managed by [Dist::Zilla](http://dzil.org) which provides a lot of benefits for managing releases and modules at the expense of longer a learning curve.
+
+However, you probably don't need it unless you want to build a release or run author tests.
+
+In order to work with Dist::Zilla's `dzil` you will need to run `carton install` manually as the Makefile uses `--without develop` to avoid unnecessary dependencies.
+
+Once those dependencies are installed, you need to use `carton exec dzil` so it can find them.
+
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,63 @@
+# This is based on the version in Dist::Zilla::PluginBundle::Author::GSG
+# See the docmentation for that module for details.
+
+DIST_NAME   ?= $(shell perl -ne '/^\s*name\s*=\s*(\S+)/ && print $$1' dist.ini )
+MAIN_MODULE ?= $(shell perl -ne '/^\s*main_module\s*=\s*(\S+)/ && print $$1' dist.ini )
+
+CARTON            ?= $(shell which carton 2>/dev/null || echo carton )
+CPANFILE_SNAPSHOT ?= $(shell \
+  carton exec perl -MFile::Spec -e \
+	'($$_) = grep { -e } map{ "$$_/../../cpanfile.snapshot" } \
+		grep { m(/lib/perl5$$) } @INC; \
+		print File::Spec->abs2rel($$_) . "\n" if $$_' 2>/dev/null )
+
+ON_DEVELOP := $(shell $(CARTON) exec -- \
+	dzil nop >/dev/null 2>/dev/null && echo $(CARTON) || echo develop )
+
+ifeq ($(MAIN_MODULE),)
+MAIN_MODULE := lib/$(subst -,/,$(DIST_NAME)).pm
+endif
+ifeq ($(CPANFILE_SNAPSHOT),)
+CPANFILE_SNAPSHOT    := cpanfile.snapshot
+endif
+CARTON_INSTALL_FLAGS ?= --without develop
+PERL_CARTON_PERL5LIB ?= $(PERL5LIB)
+
+.PHONY : test clean realclean develop carton
+
+test : $(CPANFILE_SNAPSHOT)
+	@nice $(CARTON) exec prove -lfr t
+
+# This target requires that you add 'requires "Devel::Cover";'
+# to the cpanfile and then run "carton" to install it.
+testcoverage : $(CPANFILE_SNAPSHOT)
+	$(CARTON) exec -- cover -test -ignore . -select ^lib
+
+clean:
+	$(CARTON) exec dzil clean || true
+	rm -rf .build
+
+realclean: clean
+	rm -rf local
+
+# If dzil run can provide these items with different Plugins,
+# we could update the repo with new versions by running make update.
+#
+#update: README.md LICENSE.txt
+#	@echo Everything is up to date
+#
+#README.md: $(MAIN_MODULE) dist.ini $(ON_DEVELOP)
+#	$(CARTON) exec dzil run sh -c "pod2markdown $< > ${CURDIR}/$@"
+#
+#LICENSE.txt: dist.ini $(ON_DEVELOP)
+#	$(CARTON) exec dzil run sh -c "install -m 644 LICENSE ${CURDIR}/$@"
+
+$(CPANFILE_SNAPSHOT): $(CARTON) cpanfile
+	$(CARTON) install $(CARTON_INSTALL_FLAGS)
+
+develop: $(CPANFILE_SNAPSHOT)
+	$(CARTON) install # with develop
+
+carton:
+	@echo You must install carton: https://metacpan.org/pod/Carton >&2;
+	@false;

--- a/README.mkdn
+++ b/README.mkdn
@@ -29,52 +29,6 @@ when an ABNF grammar is known.
 
 ## pegex
 
-
-
-# Development
-
-The distribution is contained in a Git repository, so simply clone the
-repository
-
-```
-$ git clone git://github.com/reneeb/Grammar-Convert-ABNF-Pegex.git
-```
-
-and change into the newly-created directory.
-
-```
-$ cd Grammar-Convert-ABNF-Pegex
-```
-
-The project uses [`Dist::Zilla`](https://metacpan.org/pod/Dist::Zilla) to
-build the distribution, hence this will need to be installed before
-continuing:
-
-```
-$ cpanm Dist::Zilla
-```
-
-To install the required prequisite packages, run the following set of
-commands:
-
-```
-$ dzil authordeps --missing | cpanm
-$ dzil listdeps --author --missing | cpanm
-```
-
-The distribution can be tested like so:
-
-```
-$ dzil test
-```
-
-To run the full set of tests (including author and release-process tests),
-add the `--author` and `--release` options:
-
-```
-$ dzil test --author --release
-```
-
 # AUTHOR
 
 Renee Baecker <reneeb@cpan.org>

--- a/cpanfile
+++ b/cpanfile
@@ -1,0 +1,28 @@
+requires perl => 'v5.20';
+
+requires 'Moo' => '1.003001';
+requires 'Parse::ABNF';
+
+on test => sub {
+    requires 'Path::Tiny';
+    requires 'Pod::Coverage::TrustPod';
+};
+
+on develop => sub {
+    requires 'Dist::Zilla::PluginBundle::Basic';
+    requires 'Dist::Zilla::PluginBundle::Filter';
+    requires 'Dist::Zilla::PluginBundle::Git';
+    requires 'Dist::Zilla::Plugin::ContributorsFile';
+    requires 'Dist::Zilla::Plugin::Git::Contributors';
+    requires 'Dist::Zilla::Plugin::GitHubREADME::Badge';
+    requires 'Dist::Zilla::Plugin::MetaJSON';
+    requires 'Dist::Zilla::Plugin::MetaProvides::Package';
+    requires 'Dist::Zilla::Plugin::MetaResources';
+    requires 'Dist::Zilla::Plugin::PodCoverageTests';
+    requires 'Dist::Zilla::Plugin::PodSyntaxTests';
+    requires 'Dist::Zilla::Plugin::PodWeaver';
+    requires 'Dist::Zilla::Plugin::Prereqs::FromCPANfile';
+    requires 'Dist::Zilla::Plugin::ReadmeAddDevInfo';
+    requires 'Dist::Zilla::Plugin::ReadmeAnyFromPod';
+    requires 'Dist::Zilla::Plugin::VersionFromModule';
+};

--- a/cpanfile
+++ b/cpanfile
@@ -5,7 +5,6 @@ requires 'Parse::ABNF';
 
 on test => sub {
     requires 'Path::Tiny';
-    requires 'Pod::Coverage::TrustPod';
 };
 
 on develop => sub {
@@ -25,4 +24,9 @@ on develop => sub {
     requires 'Dist::Zilla::Plugin::ReadmeAddDevInfo';
     requires 'Dist::Zilla::Plugin::ReadmeAnyFromPod';
     requires 'Dist::Zilla::Plugin::VersionFromModule';
+
+    # These are for the Dist::Zilla generated Pod tests.
+    requires 'Test::Pod';
+    requires 'Test::Pod::Coverage';
+    requires 'Pod::Coverage::TrustPod';
 };

--- a/cpanfile
+++ b/cpanfile
@@ -12,6 +12,7 @@ on develop => sub {
     requires 'Dist::Zilla::PluginBundle::Filter';
     requires 'Dist::Zilla::PluginBundle::Git';
     requires 'Dist::Zilla::Plugin::ContributorsFile';
+    requires 'Dist::Zilla::Plugin::Git::GatherDir';
     requires 'Dist::Zilla::Plugin::Git::Contributors';
     requires 'Dist::Zilla::Plugin::GitHubREADME::Badge';
     requires 'Dist::Zilla::Plugin::MetaJSON';

--- a/cpanfile
+++ b/cpanfile
@@ -22,7 +22,6 @@ on develop => sub {
     requires 'Dist::Zilla::Plugin::PodSyntaxTests';
     requires 'Dist::Zilla::Plugin::PodWeaver';
     requires 'Dist::Zilla::Plugin::Prereqs::FromCPANfile';
-    requires 'Dist::Zilla::Plugin::ReadmeAddDevInfo';
     requires 'Dist::Zilla::Plugin::ReadmeAnyFromPod';
     requires 'Dist::Zilla::Plugin::VersionFromModule';
 

--- a/dist.ini
+++ b/dist.ini
@@ -37,11 +37,6 @@ badges = issues
 phase = build
 place = top
 
-[ReadmeAddDevInfo]
-phase = build
-before = # AUTHOR
-add_contribution_file = 1
-
 [ContributorsFile]
 filename = CONTRIBUTORS
 

--- a/dist.ini
+++ b/dist.ini
@@ -16,8 +16,10 @@ include_authors = 1
 [@Filter]
 -bundle = @Basic
 -remove = Readme
+-remove = GatherDir
 
 [@Git]
+[Git::GatherDir]
 [MetaJSON]
 
 [MetaProvides::Package]

--- a/dist.ini
+++ b/dist.ini
@@ -50,12 +50,4 @@ repository.url = git://github.com/reneeb/Grammar-Convert-ABNF-Pegex.git
 repository.web = http://github.com/reneeb/Grammar-Convert-ABNF-Pegex
 repository.type = git
 
-[Prereqs]
-Parse::ABNF = 0
-Moo         = 1.003001
-perl        = 5.020
-
-[Prereqs / TestRequires]
-Path::Tiny = 0
-Pod::Coverage::TrustPod = 0
-
+[Prereqs::FromCPANfile]


### PR DESCRIPTION
I got here from the pullrequest.club recommending this repo, however since there were no issues, I looked at testing it out and found that Dist::Zilla likes to make my life a pain.  I find having Carton available however is much easier to do, so as I do for our work modules I added a Makefile that does an OK job of walking folks through installing just what they need.   In this case, the "local lib" goes from 52.5M down to 1.2M and installs way faster.

```
$ gmake test
/home/afresh1/.plenv/shims/carton install --without develop
Installing modules using /home/afresh1/Grammar-Convert-ABNF-Pegex/cpanfile
Successfully installed Parse-RecDescent-1.967015
Successfully installed Parse-ABNF-0.30
Successfully installed Sub-Quote-2.006006
Successfully installed Class-Method-Modifiers-2.13
Successfully installed Role-Tiny-2.002004
Successfully installed Moo-2.005004
Successfully installed Path-Tiny-0.118
7 distributions installed
Complete! Modules were installed into /home/afresh1/Grammar-Convert-ABNF-Pegex/local/5.34
t/conv.t ... ok   
t/files.t .. ok   
All tests successful.
Files=2, Tests=5,  3 wallclock secs ( 0.04 usr  0.01 sys +  3.06 cusr  0.35 csys =  3.46 CPU)
Result: PASS
```